### PR TITLE
chore: pin GitHub Actions to SHA hashes

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
         with:
           dotnet-version: 10.0.x
 
@@ -25,7 +25,7 @@ jobs:
 
       - name: Create GitHub Release and Upload Artifact
         if: github.event_name == 'push' && github.actor == 'mg0x7BE'
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           tag_name: "latest-${{ github.sha }}"
           name: "Auto-release"


### PR DESCRIPTION
## Summary
- Pin all GitHub Actions versions to immutable commit SHA hashes
- Preserves version tags as comments for readability
- Improves supply chain security by preventing tag mutation attacks

Generated by [pinact](https://github.com/suzuki-shunsuke/pinact) v3.10.0